### PR TITLE
Bugfix- Put Un/Safe Migrations in inheritence chain for all compatibi…

### DIFF
--- a/lib/pg_ha_migrations.rb
+++ b/lib/pg_ha_migrations.rb
@@ -28,3 +28,7 @@ require "pg_ha_migrations/safe_statements"
 require "pg_ha_migrations/allowed_versions"
 require "pg_ha_migrations/railtie"
 
+PgHaMigrations::AllowedVersions::ALLOWED_VERSIONS.each do |migrations_class|
+  migrations_class.prepend(PgHaMigrations::SafeStatements)
+  migrations_class.prepend(PgHaMigrations::UnsafeStatements)
+end

--- a/lib/pg_ha_migrations/safe_statements.rb
+++ b/lib/pg_ha_migrations/safe_statements.rb
@@ -188,5 +188,3 @@ module PgHaMigrations::SafeStatements
     end
   end
 end
-
-ActiveRecord::Migration.send(:prepend, PgHaMigrations::SafeStatements)

--- a/lib/pg_ha_migrations/unsafe_statements.rb
+++ b/lib/pg_ha_migrations/unsafe_statements.rb
@@ -4,7 +4,7 @@ module PgHaMigrations::UnsafeStatements
       arg_list = args.map { |arg| arg.inspect }.join(', ')
       # say_with_time args taken from https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/migration.rb#L654
       say_with_time "#{method_name}(#{arg_list})" do
-        connection.send(method_name, *args, &block)
+        self.class.superclass.send(method_name, *args, &block)
       end
     end
   end
@@ -75,5 +75,3 @@ module PgHaMigrations::UnsafeStatements
     raise PgHaMigrations::UnsafeMigrationError.new(":add_foreign_key is NOT SAFE! Explicitly call :unsafe_add_foreign_key only if you have guidance from a migration reviewer in #service-app-db.")
   end
 end
-
-ActiveRecord::Migration.send(:prepend, PgHaMigrations::UnsafeStatements)

--- a/spec/pg_ha_migrations_spec.rb
+++ b/spec/pg_ha_migrations_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe PgHaMigrations do
+  describe "prepends itself to the compatibility classes" do
+    {
+      4.2 =>  [
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Compatibility::V4_2,
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Compatibility::V5_0,
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Compatibility::V5_1,
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Current,
+        ActiveRecord::Migration,
+      ],
+      5.0 => [
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Compatibility::V5_0,
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Compatibility::V5_1,
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Current,
+        ActiveRecord::Migration,
+      ],
+      5.1 => [
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Compatibility::V5_1,
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Current,
+        ActiveRecord::Migration,
+      ],
+      5.2 => [
+        PgHaMigrations::UnsafeStatements,
+        PgHaMigrations::SafeStatements,
+        ActiveRecord::Migration::Current,
+        ActiveRecord::Migration,
+      ]
+    }.each do |version, inheritance_chain|
+      it "has the correct inheritance chain in #{version}" do
+        foo = Class.new(ActiveRecord::Migration[version])
+        expect(foo.ancestors[1..-1]).to start_with(inheritance_chain)
+      end
+    end
+  end
+end

--- a/spec/safe_migration_spec.rb
+++ b/spec/safe_migration_spec.rb
@@ -527,7 +527,7 @@ RSpec.describe PgHaMigrations::SafeStatements do
 
             indexes = ActiveRecord::Base.connection.indexes("foos")
             expect(indexes.size).to eq(1)
-            expect(indexes.first.to_h).to include(:table => "foos", :name => "index_foos_on_bar", :columns => ["bar"])
+            expect(indexes.first).to have_attributes(:table => "foos", :name => "index_foos_on_bar", :columns => ["bar"])
           end
         end
 


### PR DESCRIPTION
…lity modules

We uncovered a bug in `pg_ha_migrations` where Rails Compatibility modules/classes were being skipped for a couple of different reasons.

This PR:
- adds Safe/Unsafe Migrations modules to the inheritance chain inbetween Rails Compatibility Classes. We tried adding these modules once, but ran into test ordering problems when example classes are inherited from different Migrations versions-- specifically, when the first migration version to be included in the test was `V5_1`, a subsequent test using a migration inheriting from `V4_2` did not have access to the `pg_ha_migrations` modules *before* the usual rails migrations methods.
- Redirects unsafe migrations methods to `self.superclass` rather than directly to the Pg connection.  (an underlying assumption here is that given the typical usage of this gem, `self` in that context will be a migration file that is inheriting from some version of `ActiveRecord::Migration`)
- a one-off spec fix that was somehow missed in the last commit; in rails 5.2, the class `IndexDefinition` was changed [from a constant containing a struct](https://github.com/rails/rails/blob/v5.1.6.1/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb) to [a proper class](https://github.com/rails/rails/blob/v5.2.0/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb), meaning it no longer has a `to_h` method.